### PR TITLE
#29重複するユーザidは登録できないようにする

### DIFF
--- a/src/axios/axios-auth.js
+++ b/src/axios/axios-auth.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL:
-    'https://identitytoolkit.googleapis.com/v1'
+  baseURL: 'https://identitytoolkit.googleapis.com/v1'
 });
 
 export default instance;

--- a/src/axios/axios-db.js
+++ b/src/axios/axios-db.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL:
-  "https://firestore.googleapis.com/v1/projects/rits-chiebukuro/databases/(default)/documents"
+  baseURL: 'https://firestore.googleapis.com/v1/projects/rits-chiebukuro/databases/(default)/documents'
 });
 
 export default instance;

--- a/src/axios/axios-query.js
+++ b/src/axios/axios-query.js
@@ -1,8 +1,7 @@
 import axios from "axios";
 
 const instance = axios.create({
-  baseURL:
-    "https://firestore.googleapis.com/v1/projects/rits-chiebukuro/databases/(default)",
+  baseURL: "https://firestore.googleapis.com/v1/projects/rits-chiebukuro/databases/(default)",
 });
 
 export default instance;

--- a/src/axios/axios-query.js
+++ b/src/axios/axios-query.js
@@ -1,7 +1,7 @@
-import axios from "axios";
+import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: "https://firestore.googleapis.com/v1/projects/rits-chiebukuro/databases/(default)",
+  baseURL: 'https://firestore.googleapis.com/v1/projects/rits-chiebukuro/databases/(default)',
 });
 
 export default instance;

--- a/src/axios/axios-refresh.js
+++ b/src/axios/axios-refresh.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL:
-    'https://securetoken.googleapis.com/v1'
+  baseURL: 'https://securetoken.googleapis.com/v1'
 });
 
 export default instance;

--- a/src/components/pages/SignUp.vue
+++ b/src/components/pages/SignUp.vue
@@ -78,11 +78,6 @@ export default {
             major: this.major,
             gradeNum: this.gradeNum,
           });
-          this.email = "";
-          this.password = "";
-          this.userName = "";
-          this.major = "";
-          this.gradeNum = "";
         }
       }
     }

--- a/src/store/modules/logout.js
+++ b/src/store/modules/logout.js
@@ -2,10 +2,10 @@ import router from "../../router";
 
 const actions = {
   logout({commit}) {
+    localStorage.removeItem('RitsChiebukuro');
     commit('updateIdToken', null, {root: true});
-    localStorage.removeItem('idToken');
-    localStorage.removeItem('refreshToken');
-    localStorage.removeItem('expiryTimeMs');
+    commit('updateRefreshToken', null, {root: true});
+    commit('updateExpiryTimeMs', null, {root: true});
     commit('updateUserUid', null, {root: true});
     router.replace('/login');
   },

--- a/src/store/modules/signUp.js
+++ b/src/store/modules/signUp.js
@@ -1,7 +1,7 @@
-import axiosAuth from "../../axios/axios-auth";
-import axiosDb from "../../axios/axios-db";
-import axiosStructuredQuery from "../../axios/axios-query";
-import router from "../../router";
+import axiosAuth from '../../axios/axios-auth';
+import axiosDb from '../../axios/axios-db';
+import axiosQuery from '../../axios/axios-query';
+import router from '../../router';
 
 const actions = {
   signUp({commit, dispatch}, authData) {
@@ -35,7 +35,7 @@ const actions = {
   },
   registerUserInfo({rootGetters}, userInfo) {
     axiosDb.post(
-      "/users/",
+      '/users/',
       {
         fields: {
           uid: {
@@ -66,7 +66,7 @@ const actions = {
     );
   },
   checkUserName({dispatch}, userInfo) {
-    axiosStructuredQuery.post('/documents:runQuery', {
+    axiosQuery.post('/documents:runQuery', {
       structuredQuery: {
         select: {
           fields: [

--- a/src/store/modules/signUp.js
+++ b/src/store/modules/signUp.js
@@ -1,36 +1,30 @@
 import axiosAuth from "../../axios/axios-auth";
 import axiosDb from "../../axios/axios-db";
+import axiosStructuredQuery from "../../axios/axios-query";
 import router from "../../router";
 
 const actions = {
-  signUp({rootGetters, commit, dispatch}, authData) {
-    axiosAuth.post(
-      "/accounts:signUp?key=AIzaSyDpcvWCZbO4hP2Kzl1dcXlisQnihF16LFs",
+  signUp({commit, dispatch}, authData) {
+    axiosAuth.post('/accounts:signUp?key=AIzaSyDpcvWCZbO4hP2Kzl1dcXlisQnihF16LFs',
       {
         email: authData.email,
         password: authData.password,
         returnSecureToken: true
       },
     ).then(response => {
-      dispatch('auth/setAuthData', {
+      commit('updateUserName', authData.userName, {root: true});
+      commit('updateMajor', authData.major, {root: true});
+      commit('updateGradeNum', authData.gradeNum, {root: true});
+      dispatch('signUp/checkUserName', {
         idToken: response.data.idToken,
         refreshToken: response.data.refreshToken,
         expiresIn: response.data.expiresIn,
         userUid: response.data.localId,
-      }, {root: true}).then(() => {
-        commit('updateUserName', authData.userName, {root: true});
-        commit('updateMajor', authData.major, {root: true});
-        commit('updateGradeNum', authData.gradeNum, {root: true});
-
-        dispatch('signUp/registerUserInfo', {
-          uid: rootGetters.userUid,
-          email: authData.email,
-          userName: authData.userName,
-          major: authData.major,
-          gradeNum: authData.gradeNum,
-        }, {root: true});
-        router.push('/');
-      });
+        userName: authData.userName,
+        email: authData.email,
+        major: authData.major,
+        gradeNum: authData.gradeNum,
+      }, {root: true});
     }).catch(error => {
       for (const err of error.response.data.error.errors) {
         if (err.message == 'EMAIL_EXISTS') {
@@ -45,7 +39,7 @@ const actions = {
       {
         fields: {
           uid: {
-            stringValue: userInfo.uid
+            stringValue: userInfo.userUid
           },
           email: {
             stringValue: userInfo.email
@@ -71,6 +65,78 @@ const actions = {
       }
     );
   },
+  checkUserName({dispatch}, userInfo) {
+    axiosStructuredQuery.post('/documents:runQuery', {
+      structuredQuery: {
+        select: {
+          fields: [
+            { fieldPath: 'userName' },
+          ]
+        },
+        from: [
+          {
+            collectionId: 'users'
+          }
+        ],
+        where: {
+          compositeFilter: {
+            op: 'AND',
+            filters: [
+              {
+                fieldFilter: {
+                  field: {
+                    fieldPath: 'userName',
+                  },
+                  op: 'EQUAL',
+                  value: {
+                    stringValue: userInfo.userName,
+                  }
+                },
+              }
+            ],
+          }
+        },
+      },
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${userInfo.idToken}`
+      }
+    }).then(res => {
+      if (typeof(res.data[0].document) !== 'undefined') {
+        // ユーザ名が登録済みの場合
+        dispatch('signUp/deleteAccount', {idToken: userInfo.idToken}, {root: true});
+      } else {
+        // ユーザ名が未登録の場合
+        dispatch('auth/setAuthData', {
+          idToken: userInfo.idToken,
+          refreshToken: userInfo.refreshToken,
+          expiresIn: userInfo.expiresIn,
+          userUid: userInfo.userUid,
+        }, {root: true}).then(() => {
+          dispatch('signUp/registerUserInfo', {
+            userUid: userInfo.userUid,
+            email: userInfo.email,
+            userName: userInfo.userName,
+            major: userInfo.major,
+            gradeNum: userInfo.gradeNum,
+          }, {root: true});
+          router.push('/');
+        });
+      }
+    }).catch(error => {
+      console.log(error)
+    });
+  },
+  deleteAccount(context, userInfo) {
+    axiosAuth.post('/accounts:delete?key=AIzaSyDpcvWCZbO4hP2Kzl1dcXlisQnihF16LFs',
+      {
+        idToken: userInfo.idToken
+      },
+    ).then(() => {
+      alert('このユーザ名は既に存在しています。');
+    });
+  }
 };
 
 export default {


### PR DESCRIPTION
idTokenが無いとusersテーブルにアクセスできない
一度アカウント登録させてidTokenを取得
usersテーブルを検索し、同じユーザ名があった場合、アカウントを削除し、警告を出す。
同じユーザ名がなかったら登録

テスト項目
- [x] 同じユーザ名で登録できない