### PR TITLE
#192ベストアンサーが削除されたときに回答欄が表示されないバグ修正

### DIFF
--- a/src/components/pages/Post.vue
+++ b/src/components/pages/Post.vue
@@ -50,7 +50,7 @@
     <hr>
 
     <!-- ベストアンサーが選ばれたら回答エリアを消す -->
-    <template v-if='!post.document.fields.isResolved.booleanValue && (thread === null ? true : (typeof(thread.isResolved) === "undefined") ? true : !thread.isResolved.booleanValue)'>
+    <template v-if='!isResolved'>
       <!-- 回答エリア -->
       <div class='post-form'>
         <div>
@@ -131,7 +131,7 @@
       </div>
 
       <!-- ベストアンサーと回答を区切るための<hr> -->
-      <template v-if='!(!post.document.fields.isResolved.booleanValue && (thread === null ? true : (typeof(thread.isResolved) === "undefined") ? true : !thread.isResolved.booleanValue))'>
+      <template v-if='isResolved'>
         <hr>
       </template>
 
@@ -239,6 +239,9 @@ export default {
     favoritePostIds() {
       return this.$store.getters.favoritePostIds;
     },
+    isResolved() {
+      return this.$store.getters.isResolved;
+    }
   },
   methods: {
     deletePost() {
@@ -294,7 +297,7 @@ export default {
               isAnswered: true
             });
           }
-          
+
           this.addNotification("answer");
 
           this.comment.push({ value: '' });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -45,6 +45,7 @@ export const initialState = {
   },
   threadInfo: {
     thread: null,
+    isResolved: false,
   },
 };
 
@@ -85,6 +86,7 @@ const getters = {
   // threadInfo
   ... {
     thread: state => state.threadInfo.thread,
+    isResolved: state => state.threadInfo.isResolved,
   },
 };
 
@@ -171,6 +173,9 @@ const mutations = {
   ...{
     updateThread(state, thread) {
       state.threadInfo.thread = thread;
+    },
+    updateIsResolved(state, isResolved) {
+      state.threadInfo.isResolved = isResolved;
     },
   },
 };

--- a/src/store/modules/thread.js
+++ b/src/store/modules/thread.js
@@ -184,6 +184,7 @@ const actions = {
       }
     ).then((response) => {
       commit('updateThread', response.data.fields, {root: true});
+      commit('updateIsResolved', answerInfo.isResolved, {root: true});
       dispatch('post/updateIsResolved', {
         postId,
         isResolved: answerInfo.isResolved


### PR DESCRIPTION
- [x] ベストアンサーに設定 --> ページ遷移 --> ベストアンサーを削除 でも 回答欄が再表示される 