### PR TITLE
#213ユーザ設定変更ページの作成

### DIFF
--- a/src/components/pages/MyPage.vue
+++ b/src/components/pages/MyPage.vue
@@ -7,8 +7,6 @@
     <hr>
     <router-link to='/myPosts'>{{userName}}さんの質問</router-link>
     <hr>
-    <router-link to=''>プロフィールの変更</router-link>
-    <hr>
     <router-link to='/resetPassword'>パスワードの変更</router-link>
     <hr>
     <router-link to='/notificationConfig'>通知の設定</router-link>

--- a/src/components/pages/SignUp.vue
+++ b/src/components/pages/SignUp.vue
@@ -31,10 +31,12 @@
     <br><br>
     <br><br>
 
-    <input type="radio" v-model="degree" value="bachelor" id="bachelor" name="grade">
-    <label for="bachelor">学部生</label>
-    <input type="radio" v-model="degree" value="master" id="master" name="grade">
-    <label for="master">大学院生</label>
+    <div @click='resetMajorAndGrade'>
+      <input type="radio" v-model="degree" value="bachelor" id="bachelor" name="grade">
+      <label for="bachelor">学部生</label>
+      <input type="radio" v-model="degree" value="master" id="master" name="grade">
+      <label for="master">大学院生</label>
+    </div>
 
     <br><br>
 
@@ -48,7 +50,7 @@
         <option v-for="i in 6" v-bind:key="i.id"> {{i}}回生 </option>
       </select>
     </div>
-    <div v-else>研究科
+    <div v-else>研究科：
       <select id="master" v-model="major">
         <option disabled value="">研究科を選択してください。</option>
         <option v-for="(item) in master" v-bind:key="item.id"> {{item}} </option>
@@ -116,7 +118,11 @@ export default {
           }
         });
       }
-    }
+    },
+    resetMajorAndGrade() {
+      this.major = '';
+      this.grade = '';
+    },
   }
 }
 


### PR DESCRIPTION
プロフィール(ユーザ名)の変更は消した
もしユーザ名を変更した場合、今までの全ての質問、回答、コメント、通知のユーザ名を変更する必要がある
これは今のDBの仕様上難しそう

学部と研究科と学年は関与してるところが少ない(Postsだけ)やから更新でき安そう

